### PR TITLE
Python3対応

### DIFF
--- a/lib/fusion_utils/annotation.py
+++ b/lib/fusion_utils/annotation.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+# from __future__ import print_function
 import pysam
 
 junction_margin = 5
@@ -11,7 +12,7 @@ def get_gene_info(chr, pos, ref_gene_tb, ens_gene_tb):
     try:
         records = ref_gene_tb.fetch(chr, int(pos) - 1, int(pos) + 1)
     except Exception as inst:
-        # print >> sys.stderr, "%s: %s" % (type(inst), inst.args)
+        # print("%s: %s" % (type(inst), inst.args), file=sys.stderr)
         tabixErrorFlag = 1
         
     gene = [];
@@ -26,7 +27,7 @@ def get_gene_info(chr, pos, ref_gene_tb, ens_gene_tb):
         try:
             records = ens_gene_tb.fetch(chr, int(pos) - 1, int(pos) + 1)
         except Exception as inst:
-            # print >> sys.stderr, "%s: %s" % (type(inst), inst.args)
+            # print("%s: %s" % (type(inst), inst.args), file=sys.stderr)
             tabixErrorFlag = 1
             
         # for ensGene, just the longest gene is shown
@@ -52,7 +53,7 @@ def get_junc_info(chr, pos, ref_exon_tb, ens_exon_tb, junction_margin):
     try:
         records = ref_exon_tb.fetch(chr, int(pos) - junction_margin, int(pos) + junction_margin)
     except Exception as inst:
-        # print >> sys.stderr, "%s: %s" % (type(inst), inst.args)
+        # print("%s: %s" % (type(inst), inst.args), file=sys.stderr)
         tabixErrorFlag = 1
         
     junction = []
@@ -72,7 +73,7 @@ def get_junc_info(chr, pos, ref_exon_tb, ens_exon_tb, junction_margin):
         try:
             records = ens_exon_tb.fetch(chr, int(pos) - junction_margin, int(pos) + junction_margin)
         except Exception as inst:
-            # print >> sys.stderr, "%s: %s" % (type(inst), inst.args)
+            # print("%s: %s" % (type(inst), inst.args), file=sys.stderr)
             tabixErrorFlag = 1
              
         # for ensGene, just the longest gene is shown

--- a/lib/fusion_utils/filter.py
+++ b/lib/fusion_utils/filter.py
@@ -1,5 +1,8 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
+
+
 def filter_star_fusion(input_file, output_file, thres):
 
     hIN = open(input_file, 'r')
@@ -7,7 +10,7 @@ def filter_star_fusion(input_file, output_file, thres):
     for line in hIN:
         F = line.rstrip('\n').split('\t')
         if F[0] == "#fusion_name":
-            print >> hOUT, '\t'.join(F)
+            print('\t'.join(F), file=hOUT)
             continue 
 
         if int(F[1]) < int(thres): continue
@@ -17,7 +20,7 @@ def filter_star_fusion(input_file, output_file, thres):
         if F[7].startswith("MT"): continue
         if F[7].startswith("GL0"): continue
 
-        print >> hOUT, '\t'.join(F)
+        print('\t'.join(F), file=hOUT)
 
     hIN.close()
     hOUT.close()
@@ -44,7 +47,7 @@ def filter_genomon_fusion(input_file, output_file, thres):
 
         if int(F[20]) < thres: continue
 
-        print >> hOUT, '\t'.join(F)
+        print('\t'.join(F), file=hOUT)
 
     hIN.close()
     hOUT.close()
@@ -70,7 +73,7 @@ def filter_fusionfusion(input_file, output_file, thres):
 
         if int(F[7]) < thres: continue
 
-        print >> hOUT, '\t'.join(F)
+        print('\t'.join(F), file=hOUT)
 
     hIN.close()
     hOUT.close()

--- a/lib/fusion_utils/process.py
+++ b/lib/fusion_utils/process.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
 import re
 
 ReReg = re.compile(r'([^ \t\n\r\f\v,]+):([\+\-])(\d+)\-([^ \t\n\r\f\v,]+):([\+\-])(\d+)')
@@ -39,7 +40,7 @@ def convert_to_bedpe(input_file, output_file, margin_major, margin_minor, method
             start2 = str(int(start2) - int(margin_major))
             end2 = str(int(end2) + int(margin_minor))
 
-        print >> hOUT, '\t'.join([chr1, start1, end1, chr2, start2, end2, ID, str(read_num), dir1, dir2])
+        print('\t'.join([chr1, start1, end1, chr2, start2, end2, ID, str(read_num), dir1, dir2]), file=hOUT)
 
     hIN.close()
     hOUT.close()

--- a/lib/fusion_utils/run.py
+++ b/lib/fusion_utils/run.py
@@ -1,9 +1,8 @@
 #! /usr/bin/env python
 
 import os, subprocess
-import process
+from . import process
 import pysam
-import filter
 from fusionfusion import annotationFunction as annotation
 import annot_utils.gene
 import annot_utils.exon

--- a/lib/fusion_utils/run.py
+++ b/lib/fusion_utils/run.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
 import os, subprocess
 from . import process
 import pysam
@@ -47,7 +48,7 @@ def comp_main(args):
         ID = chr1 + ':' + dir1 + pos1 + '-' + chr2 + ':' + dir2 + pos2
 
         SV_info = fusion_comp[ID] if ID in fusion_comp else "---"
-        print >> hOUT, '\t'.join(F) + '\t' + SV_info
+        print('\t'.join(F) + '\t' + SV_info, file=hOUT)
 
     hIN.close()
     hOUT.close()
@@ -94,7 +95,7 @@ def rmdup_main(args):
         ID = chr1 + ':' + dir1 + pos1 + '-' + chr2 + ':' + dir2 + pos2
 
         if ID not in fusion_comp:
-            print >> hOUT, '\t'.join(F)
+            print('\t'.join(F), file=hOUT)
 
 
     hIN.close()
@@ -174,7 +175,7 @@ def filt_main(args):
         
         if args.filter_unspliced and junc_test == 0: continue
 
-        print >> hOUT, '\t'.join(F)
+        print('\t'.join(F), file=hOUT)
 
     hIN.close()
     hOUT.close()

--- a/resource/listExon.py
+++ b/resource/listExon.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
 import sys, gzip
 
 inputFile = sys.argv[1]
@@ -30,15 +31,12 @@ with gzip.open(inputFile, 'r') as hin:
         elif gene_type == "ens":
             gene_print_name = gene_id
         else:
-            print >> sys.stderr, "The 2nd argument should be ref or ens"
+            print("The 2nd argument should be ref or ens", file=sys.stderr)
             sys.exit(1)
  
         for i in range(0, len(exon_starts) - 1):
             key = chr + '\t' + exon_starts[i] + '\t' + exon_ends[i]
             if strand == "+":
-                print key + '\t' + gene_print_name + '\t' + str(size) + '\t' + "+"
+                print(key + '\t' + gene_print_name + '\t' + str(size) + '\t' + "+")
             else:
-                print key + '\t' + gene_print_name + '\t' + str(size) + '\t' + "-"
-
-
-
+                print(key + '\t' + gene_print_name + '\t' + str(size) + '\t' + "-")

--- a/resource/listGene.py
+++ b/resource/listGene.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
 import sys, gzip
 
 inputFile = sys.argv[1]
@@ -25,11 +26,11 @@ with gzip.open(inputFile, 'r') as hin:
 
         key = chr + '\t' + gene_start + '\t' + gene_end
         if gene_type == "ref": 
-            print key + '\t' + symbol + '\t' + str(size) + '\t' + strand
+            print(key + '\t' + symbol + '\t' + str(size) + '\t' + strand)
         elif gene_type == "ens":
-            print key + '\t' + gene_id + '\t' + str(size) + '\t' + strand
+            print(key + '\t' + gene_id + '\t' + str(size) + '\t' + strand)
         else:
-            print >> sys.stderr, "The 2nd argument should be ref or ens"
+            print("The 2nd argument should be ref or ens", file=sys.stderr)
             sys.exit(1)
 
 

--- a/resource/make_ucsc_grch.py
+++ b/resource/make_ucsc_grch.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
 import sys
 
 input_file = sys.argv[1]
@@ -9,7 +10,7 @@ with open(input_file, 'r') as hin:
         if line.startswith('#'): continue
         F = line.rstrip('\n\r').split('\t')
         if F[4].startswith('CM'):
-            print F[2] + '\t' + F[9]
+            print(F[2] + '\t' + F[9])
         else:
-            print F[4] + '\t' + F[9]
+            print(F[4] + '\t' + F[9])
 

--- a/resource/proc_tophat_fusion_html.py
+++ b/resource/proc_tophat_fusion_html.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 
+from __future__ import print_function
 import sys, re
 
 input_file = sys.argv[1]
@@ -65,7 +66,7 @@ with open(input_file, 'r') as hin:
         if read_count == 8:
             temp_pair = line
             if print_on == 1:
-                print '\t'.join([temp_chr1, temp_pos1, temp_dir1, temp_chr2, temp_pos2, temp_dir2, temp_read, temp_pair, temp_gene1, temp_gene2])
+                print('\t'.join([temp_chr1, temp_pos1, temp_dir1, temp_chr2, temp_pos2, temp_dir2, temp_read, temp_pair, temp_gene1, temp_gene2]))
                 print_on = 0
 
 """        


### PR DESCRIPTION
このプルリクエストは `fusion_utils` をPython3上でもエラーなく動作できるよう修正します。Python 2.7.18 および 3.10.4 にて動作確認済みです。

具体的には、以下の2点の修正をします：

1. 暗黙的相対importの除去 (2bce3ad0642145111442995e622e83c7161be415)
2. print文の除去 (77cd188fc683f3e4a097dfd06ae58037ac54a88b)

1.については、Python3で[PEP-328](https://peps.python.org/pep-0328/)で提案された明示的相対importが採用されたことへの対応です。
従来、同一パッケージ内の別モジュールを、

```python
import foo
```

のようにアクセスできていた(暗黙的相対import)ものがPython3ではエラーになるようになりました。このため、

```python
from . import foo
```

等のように、 `.` をつけて相対importであることを明示します。

2.については、Python3で`print`文が廃止された([PEP-3105](https://peps.python.org/pep-3105/))ことへの対応です。`print`の括弧が必須となり、出力先を`file`キーワード引数で指定するようになりました。また、

```python
from __future__ import print_function
```

という記述を追加することで、Python2でも動作するようにしています。